### PR TITLE
no more 'page:1' in url

### DIFF
--- a/classes/paginationhelper.php
+++ b/classes/paginationhelper.php
@@ -49,8 +49,12 @@ class PaginationHelper extends Iterator
         $this->page_count = ceil($collection->count() / $this->items_per_page);
 
         for ($x=1; $x <= $this->page_count; $x++) {
-            $this->items[$x] = new PaginationPage($x, '/page' . $config->get('system.param_sep') . $x);
-        }
+            if ($x === 1) {
+                $this->items[$x] = new PaginationPage($x, '');
+            } else {
+                $this->items[$x] = new PaginationPage($x, '/page' . $config->get('system.param_sep') . $x);
+            }
+       }
     }
 
     /**


### PR DESCRIPTION
Change the first page url from :
> http://localhost/blog/page:1

to :
> http://localhost/blog

<sup>(works with `tags` too and probably all taxonomies)</sup>

---

This is for avoid 'Duplicate Content' which is not good for SEO
