### PR TITLE
Fix errors on saving plugin configuration in admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ You should now have all the plugin files under
 
 ```
 enabled: true
-path: /blog
 built_in_css: true
 delta: 0
 ```

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -25,6 +25,16 @@ form:
       validate:
         type: bool
 
+    delta:
+        type: text
+        size: x-small
+        label: Delta (How many pages to show left and right of the current page)
+        default: 0
+        help: The 'delta' value controls how many pages left and right of the current page are visible. If set to 0 all pages will be shown.
+        validate:
+          type: number
+          min: 0
+
     built_in_css:
       type: toggle
       label: Use built in CSS

--- a/pagination.yaml
+++ b/pagination.yaml
@@ -1,4 +1,3 @@
 enabled: true
-path: /blog
 built_in_css: true
 delta: 0


### PR DESCRIPTION
Add blueprint for `delta`. Remove `path` because it's not used