### PR TITLE
Fix template location due to partials.

### DIFF
--- a/pagination.php
+++ b/pagination.php
@@ -45,7 +45,7 @@ class PaginationPlugin extends Plugin
      */
     public function onTwigTemplatePaths()
     {
-        $this->grav['twig']->twig_paths[] = __DIR__ . '/templates';
+        $this->grav['twig']->twig_paths[] = __DIR__ . '/templates/partials';
     }
 
     /**


### PR DESCRIPTION
Grav 0.9.34 was getting error of `RuntimeException (404) Template "pagination.html.twig" is not defined ()'
Fixed by changing template location in Grav's twig_paths.