### PR TITLE
Rewrite README's Usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,24 +26,70 @@ The 'delta' value controls how many pages left and right of the current page are
 
 If you need to change any value, then the best process is to copy the [pagination.yaml](pagination.yaml) file into your `users/config/plugins/` folder (create it if it doesn't exist), and then modify there.  This will override the default settings.
 
-# Usage
+# Usage for content authors
 
-To use `pagination`, you need a blog-like structured page. Then, at the header of the main page, you will add the `pagination: true` setting.
+To use this plugin:
+
+- the `pagination` plugin must be installed and enabled
+- the active theme must have pagination support (most Grav themes support pagination; if you’re building your own theme, see the next section for adding pagination support)
+
+On the content side, you should have a blog-like structure, for example:
 
 ```
+blog/
+    blog.md
+    my-cool-blog-post/
+        item.md
+    another-post/
+        item.md
+```
+
+Then in your `blog.md`, set up the page’s collection using YAML front-matter:
+
+```yaml
 ---
-title: Blog
-blog_url: blog
-pagination: true
+title: My Gravtastic Blog
+content:
+  items: '@self.children'
+  order:
+    by: header.date
+    dir: desc
+  pagination: true
+  limit: 10
 ---
 
 # My Gravtastic Blog
 ## A tale of **awesomazing** adventures
 ```
 
-### Override the pagination HTML
+Your `/blog` page should now list the 10 most recent blog posts, and show pagination links.
 
-If you want to override the look and feel of the pagination, copy the template file [pagination.html.twig][pagination] into the templates folder of your custom theme and that is it.
+
+# Usage for theme developers
+
+### Including the default pagination template
+
+If you are developing your own theme and want to support pagination, you need to include the pagination template in the relevant pages. For instance in `blog.html.twig`:
+
+```twig
+{# /your/site/grav/user/themes/custom-theme/templates/blog.html.twig #}
+
+{% set collection = page.collection() %}
+
+{# Render the list of blog posts (automatically filtered when using pagination) #}
+{% for child in collection %}
+   ...
+{% endfor %}
+
+{# Render the pagination list #}
+{% if config.plugins.pagination.enabled and collection.params.pagination %}
+    {% include 'partials/pagination.html.twig' with {'base_url':page.url, 'pagination':collection.params.pagination} %}
+{% endif %}
+```
+
+### Overriding the pagination HTML
+
+If you want to override the look and feel of the pagination, copy the template file [pagination.html.twig][pagination] into the templates folder of your custom theme:
 
 ```
 /your/site/grav/user/themes/custom-theme/templates/partials/pagination.html.twig
@@ -51,5 +97,5 @@ If you want to override the look and feel of the pagination, copy the template f
 
 You can now edit the override and tweak it to meet your needs.
 
-[pagination]: templates/pagination.html.twig
+[pagination]: templates/partials/pagination.html.twig
 [grav]: http://github.com/getgrav/grav


### PR DESCRIPTION
As a follow-up to issue #17 (which is fixed IMO on the technical side, but still shows that doc updates would be useful), I’m proposing a rewrite of the "Usage" section of the README.

Notable changes:

- Split usage in two: content setup and theme development
- In the content setup, adding a full example for making a blog-like page collection
- Previous doc had the `pagination:true` config at the `page.header.pagination` level. It seems that the pagination plugin expects it at the `page.header.content.pagination` level.
- Added a sub-section about including the `partials/pagination.html.twig` template (when developing your own `blog.html.twig` template or equivalent).
- Mostly tried to write what would have helped me fumble a bit less as a newcomer to Grav and to this plugin. :)