### PR TITLE
Unbreak pagination urls attempt #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,19 +136,6 @@ The above example is taken from http://ami-web.nl/events. This code creates a pa
 
 ### Rendering the paginated collection
 
-The rest is identical to the standard procedure.
-
-```twig
-{% set collection = page.find('/other/_events').children %}
-{% set limit = 5 %}
-{% set ignore_url_param_array = ['event'] %}
-{% do paginate(collection, limit, ignore_url_param_array) %}
-```
-
-The above example is taken from http://ami-web.nl/events. This code creates a paginated collection with 5 items per page (the event summary list) which is presented together with an active event. The active event appears in only one of the summary pages. Consequently, the url parameter `event` should be filtered out so it does not show up in the pagination bar's links, preventing inconsistencies with different page parameters. Any non listed url parameters (except the page parameter) are passed through unaffected. The requested page contains logic to pick a sensible default event.
-
-## Rendering the paginated collection
-
 The rest is identical to the standard procedure:
 
 ```twig

--- a/templates/partials/pagination.html.twig
+++ b/templates/partials/pagination.html.twig
@@ -5,7 +5,7 @@
 
 <ul class="pagination">
     {% if pagination.hasPrev %}
-        {% set url =  base_url ~ (pagination.params ~ pagination.prevUrl)|replace({'//':'/'}) %}
+        {% set url =  base_url ~ (pagination.params ~ pagination.prevUrl)|replace({'//':'/'})|replace({':/':'://'}) %}
         <li><a rel="prev" href="{{ url }}">&laquo;</a></li>
     {% else %}
         <li><span>&laquo;</span></li>
@@ -16,7 +16,7 @@
         {% if paginate.isCurrent %}
             <li><span>{{ paginate.number }}</span></li>
         {% elseif paginate.isInDelta %}
-            {% set url = base_url ~ (pagination.params ~ paginate.url)|replace({'//':'/'}) %}
+            {% set url = base_url ~ (pagination.params ~ paginate.url)|replace({'//':'/'})|replace({':/':'://'}) %}
             <li><a href="{{ url }}">{{ paginate.number }}</a></li>
         {% elseif paginate.isDeltaBorder %}
             <li class="gap"><span>&hellip;</span></li>
@@ -24,7 +24,7 @@
 
     {% endfor %}
     {% if pagination.hasNext %}
-        {% set url = base_url ~ (pagination.params ~ pagination.nextUrl)|replace({'//':'/'}) %}
+        {% set url = base_url ~ (pagination.params ~ pagination.nextUrl)|replace({'//':'/'})|replace({':/':'://'}) %}
         <li><a rel="next" href="{{ url }}">&raquo;</a></li>
     {% else %}
         <li><span>&raquo;</span></li>


### PR DESCRIPTION
The previous "unfix" unfixed my application :-) Let's try again to solve the problem to everyone's satisfaction by appending ```|replace({':/':'://'})``` to each pagination url in pagination.html.twig.