### PR TITLE
fix malformed pagination urls attempt #2

### DIFF
--- a/templates/partials/pagination.html.twig
+++ b/templates/partials/pagination.html.twig
@@ -5,7 +5,7 @@
 
 <ul class="pagination">
     {% if pagination.hasPrev %}
-        {% set url =  (base_url ~ pagination.params ~ pagination.prevUrl)|replace({'//':'/'}) %}
+        {% set url =  (base_url ~ pagination.params ~ pagination.prevUrl)|replace({'//':'/'})|replace({':/':'://'}) %}
         <li><a rel="prev" href="{{ url }}">&laquo;</a></li>
     {% else %}
         <li><span>&laquo;</span></li>
@@ -16,7 +16,7 @@
         {% if paginate.isCurrent %}
             <li><span>{{ paginate.number }}</span></li>
         {% elseif paginate.isInDelta %}
-            {% set url = (base_url ~ pagination.params ~ paginate.url)|replace({'//':'/'}) %}
+            {% set url = (base_url ~ pagination.params ~ paginate.url)|replace({'//':'/'})|replace({':/':'://'}) %}
             <li><a href="{{ url }}">{{ paginate.number }}</a></li>
         {% elseif paginate.isDeltaBorder %}
             <li class="gap"><span>&hellip;</span></li>
@@ -24,7 +24,7 @@
 
     {% endfor %}
     {% if pagination.hasNext %}
-        {% set url = (base_url ~ pagination.params ~ pagination.nextUrl)|replace({'//':'/'}) %}
+        {% set url = (base_url ~ pagination.params ~ pagination.nextUrl)|replace({'//':'/'})|replace({':/':'://'}) %}
         <li><a rel="next" href="{{ url }}">&raquo;</a></li>
     {% else %}
         <li><span>&raquo;</span></li>


### PR DESCRIPTION
The previous 'unfix' of pagination urls unfixed my application :-). Since the resulting urls are in fact malformed when base_url contains a scheme id and some browsers don't like this, let's try again to solve this in a different way by appending the filter ```|replace({':/':'://'})``` to each url. Supposedly, this will only affect the scheme part of the url, if any.