### PR TITLE
add firstUrl() and lastUrl() to allow jumping directly to the first or last page

### DIFF
--- a/classes/paginationhelper.php
+++ b/classes/paginationhelper.php
@@ -98,6 +98,20 @@ class PaginationHelper extends Iterator
     }
 
     /**
+     * Return first url.
+     *
+     * @return string|null
+     */
+    public function firstUrl()
+    {
+        if (array_key_exists(1, $this->items)) {
+            return $this->items[1]->url;
+        }
+
+        return null;
+    }
+
+    /**
      * Return previous url.
      *
      * @return string|null
@@ -120,6 +134,20 @@ class PaginationHelper extends Iterator
     {
         if (array_key_exists($this->current +1, $this->items)) {
             return $this->items[$this->current +1]->url;
+        }
+
+        return null;
+    }
+
+    /**
+     * Return last url.
+     *
+     * @return string|null
+     */
+    public function lastUrl()
+    {
+        if (array_key_exists(count($this->items), $this->items)) {
+            return $this->items[count($this->items)]->url;
         }
 
         return null;

--- a/templates/partials/pagination.html.twig
+++ b/templates/partials/pagination.html.twig
@@ -5,10 +5,13 @@
 
 <ul class="pagination">
     {% if pagination.hasPrev %}
+        {% set url =  (base_url ~ pagination.params ~ pagination.firstUrl)|replace({'//':'/'}) %}
+        <li><a rel="prev" href="{{ url }}">&lt;&lt;</a></li>
         {% set url =  (base_url ~ pagination.params ~ pagination.prevUrl)|replace({'//':'/'}) %}
-        <li><a rel="prev" href="{{ url }}">&laquo;</a></li>
+        <li><a rel="prev" href="{{ url }}">&lt;</a></li>
     {% else %}
-        <li><span>&laquo;</span></li>
+        <li><span>&lt;&lt;</span></li>
+        <li><span>&lt;</span></li>
     {% endif %}
 
     {% for paginate in pagination %}
@@ -25,9 +28,12 @@
     {% endfor %}
     {% if pagination.hasNext %}
         {% set url = (base_url ~ pagination.params ~ pagination.nextUrl)|replace({'//':'/'}) %}
-        <li><a rel="next" href="{{ url }}">&raquo;</a></li>
+        <li><a rel="next" href="{{ url }}">&gt;</a></li>
+        {% set url = (base_url ~ pagination.params ~ pagination.lastUrl)|replace({'//':'/'}) %}
+        <li><a rel="next" href="{{ url }}">&gt;&gt;</a></li>
     {% else %}
-        <li><span>&raquo;</span></li>
+        <li><span>&gt;</span></li>
+        <li><span>&gt;&gt;</span></li>
     {% endif %}
 </ul>
 


### PR DESCRIPTION
I have used `items[1]` instead of just returning `null` for `firstUrl()` in case
something changes in the way the pagination is handled.

To add the first and last buttons, I changed from `&raquo;` and `&laquo;` to `&gt;`
and `&lt;` so I could add similar looking first and last buttons.