### PR TITLE
add toggle to activate functionality in admin

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -48,3 +48,15 @@ form:
         0: PLUGIN_ADMIN.DISABLED
       validate:
         type: bool
+
+    admin_active:
+      type: toggle
+      label: PLUGIN_PAGINATION.ADMIN_ACTIVE
+      help: PLUGIN_PAGINATION.ADMIN_ACTIVE_HELP
+      highlight: 1
+      default: 0
+      options:
+        1: PLUGIN_ADMIN.ENABLED
+        0: PLUGIN_ADMIN.DISABLED
+      validate:
+        type: bool

--- a/languages.yaml
+++ b/languages.yaml
@@ -4,6 +4,8 @@ en:
     DELTA_HELP: 'How many pages to show left and right of the current page'
     BUILTIN_CSS: 'Use built in CSS'
     BUILTIN_CSS_HELP: 'Include the CSS provided by the Pagination plugin'
+    ADMIN_ACTIVE: 'Active in admin'
+    ADMIN_ACTIVE_HELP: 'Activate pagination functionality in admin'
 
 ru:
   PLUGIN_PAGINATION:

--- a/pagination.php
+++ b/pagination.php
@@ -45,7 +45,7 @@ class PaginationPlugin extends Plugin
      */
     public function onPluginsInitialized()
     {
-        if ($this->isAdmin()) {
+        if ($this->isAdmin() && !$this->config->get('plugins.pagination.admin_active', false)) {
             $this->active = false;
             return;
         }

--- a/pagination.yaml
+++ b/pagination.yaml
@@ -1,3 +1,4 @@
 enabled: true
 built_in_css: true
 delta: 0
+admin_active: 0


### PR DESCRIPTION
Pagination can not be used in admin right now. As I am currently trying to add some custom admin pages, this feature would be really nice. I think @NicoHood also requires that feature.

It is deactivated by default.