### PR TITLE
Make page_count and current accessible from Twig

### DIFF
--- a/classes/plugin/PaginationHelper.php
+++ b/classes/plugin/PaginationHelper.php
@@ -122,6 +122,30 @@ class PaginationHelper extends Iterator
 
         return null;
     }
+    
+    /**
+     * Return the current page
+     */
+    public function currentPage()
+    {
+        return $this->current;
+    }
+    
+    /**
+     * Return the items per page
+     */
+    public function itemsPerPage()
+    {
+        return $this->items_per_page;
+    }
+    
+    /**
+     * Return the total number of pages
+     */
+    public function pageCount()
+    {
+        return $this->page_count;
+    }
 
     public function params()
     {

--- a/classes/plugin/PaginationHelper.php
+++ b/classes/plugin/PaginationHelper.php
@@ -56,7 +56,7 @@ class PaginationHelper extends Iterator
         }
 
         $this->items_per_page = $params['limit'];
-        $this->page_count = ceil($collection->count() / $this->items_per_page);
+        $this->page_count = intval(ceil($collection->count() / $this->items_per_page));
 
         for ($x=1; $x <= $this->page_count; $x++) {
             if ($x === 1) {
@@ -125,6 +125,8 @@ class PaginationHelper extends Iterator
     
     /**
      * Return the current page
+     *
+     * @return int
      */
     public function currentPage()
     {
@@ -133,6 +135,8 @@ class PaginationHelper extends Iterator
     
     /**
      * Return the items per page
+     *
+     * @return int
      */
     public function itemsPerPage()
     {
@@ -141,6 +145,8 @@ class PaginationHelper extends Iterator
     
     /**
      * Return the total number of pages
+     *
+     * @return int
      */
     public function pageCount()
     {

--- a/classes/plugin/PaginationHelper.php
+++ b/classes/plugin/PaginationHelper.php
@@ -56,7 +56,7 @@ class PaginationHelper extends Iterator
         }
 
         $this->items_per_page = $params['limit'];
-        $this->page_count = intval(ceil($collection->count() / $this->items_per_page));
+        $this->page_count = (int)ceil($collection->count() / $this->items_per_page);
 
         for ($x=1; $x <= $this->page_count; $x++) {
             if ($x === 1) {


### PR DESCRIPTION
There are times when it is necessary to show the page_count and current page in Twig templates (for example, "2/6" to mean "page 2 of 6"). This pull request aims to expose variables `current`, `items_per_page`, and `page_count`.

I am not good with making pull requests, so if there is any mistake, please tell me, and I will try my best to fix it. Thanks!